### PR TITLE
Updated data feed to use permenant URL

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 var app = angular.module('MasterBlaster', []);
 
 app.controller('BlastList', ['$scope', '$http', function($scope, $http) {
-  $http.get('https://raw.githubusercontent.com/segfly/ReferenceRepo/datafeeds/blastfeed.json').success(function(data) {
+  $http.get('https://raw.githubusercontent.com/CSCO-DevOps-Bootcamp/ReferenceRepo/datafeeds/blastfeed.json').success(function(data) {
     $scope.blasts = data.records;
   });
 }]);


### PR DESCRIPTION
I updated the master repo with new branches containing the `blastfeed.json`.
I was thinking about using a URL shortener but looks like redirects are not followed. Is that an option that needs to be enabled?

E.g. https://j.mp/bootcamp-blastfeed
